### PR TITLE
Add the appropriate default value for the checkout-path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ By default, the key name is `GIT_SSH_CHECKOUT_PLUGIN_SSH_KEY`.
 
 Replace the path the repository will be checked out to.
 
-By default, the path will be `.`, the base path for the current build.
+By default, the path will be the value of `BUILDKITE_BUILD_CHECKOUT_PATH`, the base path for the current build.
 
 ## Examples
 


### PR DESCRIPTION
The code reflects this change already, and that update was missed when made from the README.