### PR TITLE
Ensure the branch of a build is used when the code is checked out

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -27,4 +27,14 @@ if [ "${DRY_RUN}" != "true" ]; then
   # Clone the repository
   git clone "${REPOSITORY_URL_OPTION}" "${CHECKOUT_PATH_OPTION}" \
     --config core.sshCommand="ssh -i ${KEY_NAME} -o StrictHostKeyChecking=no -y"
+
+  cd "${CHECKOUT_PATH_OPTION}"
+
+  # Clean up the clone
+  git clean -ffxdq
+
+  # Checkout the branch
+  if [ "${BUILDKITE_BRANCH}" != "" ]; then
+    git fetch -v --prune -- origin "refs/heads/${BUILDKITE_BRANCH}"
+  fi
 fi

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -34,11 +34,13 @@ if [ "${DRY_RUN}" != "true" ]; then
   git clean -ffxdq
 
   # Checkout the branch
-  if [ "${BUILDKITE_BRANCH}" != "" ]; then
+  if [ "${BUILDKITE_BRANCH:-}" != "" ]; then
     # Fetch the branch
     git fetch -v --prune -- origin "refs/heads/${BUILDKITE_BRANCH}"
+  fi
 
-    # Checkout the SHA
+  # Checkout the SHA
+  if [ "${BUILDKITE_COMMIT:-}" != "" ]; then
     git checkout -f "${BUILDKITE_COMMIT}"
   fi
 fi

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -35,6 +35,10 @@ if [ "${DRY_RUN}" != "true" ]; then
 
   # Checkout the branch
   if [ "${BUILDKITE_BRANCH}" != "" ]; then
+    # Fetch the branch
     git fetch -v --prune -- origin "refs/heads/${BUILDKITE_BRANCH}"
+
+    # Checkout the SHA
+    git checkout -f "${BUILDKITE_COMMIT}"
   fi
 fi


### PR DESCRIPTION
After the `git clone` happens, the plugin is completed. This means that on a branch build or anything other than `{default}/HEAD` the SHA used is overridden to the latest on the default branch.

The environment for the build is populated with `BUILDKITE_BRANCH` which we can fetch and use for the rest of the build as would be expected.