### PR TITLE
Ensure when HEAD is used as the commit that the appropriate branch is selected

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ steps:
   - label: ":pipeline:"
     command: "buildkite-agent pipeline upload"
     plugins:
-      - git-ssh-checkout#v0.4.0:
+      - git-ssh-checkout#v0.4.1:
           ssh-secret-key-name: 'SUPER_SECRET_SSH_KEY'
 ```
 
@@ -49,7 +49,7 @@ steps:
   - label: ":hammer_and_pick: Run linter"
     command: "make lint"
     plugins: &base-plugins
-      - git-ssh-checkout#v0.4.0: &checkout-plugin
+      - git-ssh-checkout#v0.4.1: &checkout-plugin
           ssh-secret-key-name: 'SUPER_SECRET_SSH_KEY'
 
   - label: ":hammer_and_pick: Run tests"
@@ -59,7 +59,7 @@ steps:
   - label: ":docker: Build image"
     command: "make build-image"
     plugins:
-      - git-ssh-checkout#v0.4.0: *checkout-plugin
+      - git-ssh-checkout#v0.4.1: *checkout-plugin
       - ecr#v2.9.0:
           login: true
 ```

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -39,8 +39,10 @@ if [ "${DRY_RUN}" != "true" ]; then
     git fetch -v --prune -- origin "refs/heads/${BUILDKITE_BRANCH}"
   fi
 
-  # Checkout the SHA
-  if [ "${BUILDKITE_COMMIT:-}" != "" ]; then
+  # Checkout the correct ref to continue the build
+  if [ "${BUILDKITE_COMMIT:-}" = "HEAD" || "${BUILDKITE_COMMIT}" = "" ]; then
+    git checkout -f "origin/${BUILDKITE_BRANCH}"
+  else
     git checkout -f "${BUILDKITE_COMMIT}"
   fi
 fi

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -40,7 +40,7 @@ if [ "${DRY_RUN}" != "true" ]; then
   fi
 
   # Checkout the correct ref to continue the build
-  if [ "${BUILDKITE_COMMIT:-}" = "HEAD" || "${BUILDKITE_COMMIT}" = "" ]; then
+  if [ "${BUILDKITE_COMMIT:-}" = "HEAD" ] || [ "${BUILDKITE_COMMIT}" = "" ]; then
     git checkout -f "origin/${BUILDKITE_BRANCH}"
   else
     git checkout -f "${BUILDKITE_COMMIT}"


### PR DESCRIPTION
When running a manual build for a branch, the branch was being ignored when the commit is set to `HEAD`. We need to detect that, and properly switch to the branch to have the right SHA picked up.